### PR TITLE
replace yargs with built-in parseArgs

### DIFF
--- a/bin/couchsnap.bin.js
+++ b/bin/couchsnap.bin.js
@@ -1,17 +1,74 @@
 #!/usr/bin/env node
 
-// command-line args
+const syntax = 
+`Syntax:
+--url/-u           (COUCH_URL)      CouchDB URL          (required)
+--database/--db/-d (COUCH_DATABASE) CouchDB Datbase name (required)
+--deletions                         Include deleted docs (default: false)
+--version/v                         Show app version     (default: false)
+`
 const url = process.env.COUCH_URL || 'http://localhost:5984'
 const db = process.env.COUCH_DATABASE
-const args = require('yargs')
-  .option('url', { alias: 'u', describe: 'CouchDB URL', default: url })
-  .option('database', { alias: ['db', 'd'], describe: 'CouchDB database name', demandOption: !db, default: db })
-  .option('deletions', { describe: 'Include deletions', type: 'boolean', demandOption: false, default: false })
-  .help('help')
-  .argv
+const app = require('../package.json')
+const { parseArgs } = require('node:util')
+const argv = process.argv.slice(2)
+const options = {
+  url: {
+    type: 'string',
+    short: 'u',
+    default: url
+  },
+  database: {
+    type: 'string',
+    short: 'd',
+    default: db
+  },
+  db: {
+    type: 'string',
+    default: db
+  },
+  deletions: {
+    type: 'boolean',
+    default: false
+  },
+  version: {
+    type: 'boolean',
+    short: 'v',
+    default: false
+  },
+  help: {
+    type: 'boolean',
+    short: 'h',
+    default: false
+  }
+}
+
+// parse command-line options
+const { values } = parseArgs({ argv, options })
+if (values.db) {
+  values.database = values.db
+  delete values.db
+}
+// version mode
+if (values.version) {
+  console.log(`${app.name} ${app.version}`)
+  process.exit(0)
+}
+
+// help mode
+if (values.help) {
+  console.log(syntax)
+  process.exit(0)
+}
+
+// must supply URL & database
+if (!values.url || !values.database) {
+  console.error(syntax, 'Error: You must supply a url and database name')
+  process.exit(1)
+}
 
 // start the snapshot
 const couchsnap = require('../index.js')
-couchsnap.start(args)
+couchsnap.start(values)
   .then(console.log)
   .catch(console.error)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "couchsnap",
   "version": "0.6.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -9,8 +9,7 @@
       "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonpour": "^1.0.2",
-        "yargs": "^17.7.2"
+        "jsonpour": "^1.0.2"
       },
       "bin": {
         "couchsnap": "bin/couchsnap.bin.js"
@@ -181,126 +180,6 @@
       "engines": {
         "node": ">=12"
       }
-    }
-  },
-  "dependencies": {
-    "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
-    "cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
-    },
-    "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "jsonpour": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jsonpour/-/jsonpour-1.0.2.tgz",
-      "integrity": "sha512-SSWWn5t7FgToXJXZ3mFbXYne0CdBF2F1Gww6takkRplTzukI48C1Mi0FRbEXb45KC0f0tE2wWRHQhKwZETR+9g=="
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      }
-    },
-    "wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "requires": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      }
-    },
-    "yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "homepage": "https://github.com/glynnbird/couchsnap#readme",
   "dependencies": {
-    "jsonpour": "^1.0.2",
-    "yargs": "^17.7.2"
+    "jsonpour": "^1.0.2"
   },
   "bin": {
     "couchsnap": "bin/couchsnap.bin.js"


### PR DESCRIPTION
Remove a dependency. This can merge when Node 16 falls out of support in Oct 2023. It relies on util.parseArgs which is only in available in v18.3.0, v16.17.0 onwards.

See https://nodejs.org/api/util.html#utilparseargsconfig