### PR TITLE
remove colons from filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const start = async (opts) => {
   const meta = await loadMeta(opts.database)
   opts.since = meta.since
   meta.startTime = new Date().toISOString()
-  const outputFilename = `${meta.db}-snapshot-${meta.startTime}.jsonl`.replace(/:/g,"") // remove colon from time compliant filenames
+  const outputFilename = `${meta.db}-snapshot-${meta.startTime}.jsonl`.replace(/:/g,"") // remove colons for compliant filenames
   const tempOutputFile = `_tmp_${outputFilename}`
   let status
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ const start = async (opts) => {
   const meta = await loadMeta(opts.database)
   opts.since = meta.since
   meta.startTime = new Date().toISOString()
-  const outputFilename = `${meta.db}-snapshot-${meta.startTime}.jsonl`
+  const outputFilename = `${meta.db}-snapshot-${meta.startTime}.jsonl`.replace(/:/g,"") // remove colon from time compliant filenames
   const tempOutputFile = `_tmp_${outputFilename}`
   let status
 


### PR DESCRIPTION
This PR should resolve the "no such file or directory" errors, raised at either the start (on windows) or end of the backup(on linux), allowing the backup to run to completion. 

Currently it leaves the _tmp* file because the OS can't locate the file, presumably because it doesn't recognize colons in filename.

Example of error raised - RHEL 8:
```
/usr/local/bin/couchsnap --db sensor_event                                                                                                  
spooling changes for sensor_event since 0
Error: ENOENT: no such file or directory, rename '_tmp_sensor_event-snapshot-2024-06-27T09:13:26.336Z.jsonl' -> 'sensor_event-snapshot-2024-06-27T09:13:26.336Z.jsonl'
    at Object.renameSync (node:fs:1026:3)
    at Object.start (/usr/local/lib/node_modules/couchsnap/index.js:84:6)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  errno: -2,
  syscall: 'rename',
  code: 'ENOENT',
  path: '_tmp_sensor_event-snapshot-2024-06-27T09:13:26.336Z.jsonl',
  dest: 'sensor_event-snapshot-2024-06-27T09:13:26.336Z.jsonl'
}

/usr/local/bin/couchsnap --version
couchsnap 0.7.0

node --version
v16.20.2

npm --version
8.19.4
```
